### PR TITLE
Export gzip copy of XZ-compressed datasets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.xz filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text

--- a/data/affiliations/countries.tsv.gz
+++ b/data/affiliations/countries.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27b68e09107a7dc911f3dfd48b2f7f871dd40879a0d106cfa863700c3df9c0a7
+size 11180807

--- a/data/affiliations/geocode.jsonl.gz
+++ b/data/affiliations/geocode.jsonl.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed734a7c715ee1d608c62903a051293ab9c240ecb1a95b8c9ff2c6b90a3118ca
+size 29003845

--- a/data/names/corresponding-authors.tsv.gz
+++ b/data/names/corresponding-authors.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab49cb641028be327c58bc6b1e96babdfaa7c998b707be2754139df89ea946f6
+size 3449219

--- a/data/names/fore-names.tsv.gz
+++ b/data/names/fore-names.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686477fb70847eb29c6cc6e3f79a6f3b87fe5054c7fe8564e4d3ab4e91ce7b1f
+size 834056

--- a/data/names/full-names.tsv.gz
+++ b/data/names/full-names.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:197fb6511d4156815162a7b1f12f424f2935d8e4407f54220fe01a131b85e862
+size 9148296

--- a/data/names/last-names.tsv.gz
+++ b/data/names/last-names.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80286e437f1404eb86a52f20e55dde69f1b3ff525d001a8681b72eabbb9d9bc4
+size 1262520

--- a/data/pmc/affiliations.tsv.gz
+++ b/data/pmc/affiliations.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f3aeca38cd16b469a0927dd9ba946533e273cc80708cd91d16d431d4566d764
+size 2299932

--- a/data/pmc/authors.tsv.gz
+++ b/data/pmc/authors.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3e5550fc84f1098b9475f162831e448fa1fd0fadc593509a429f5bccf2476db
+size 1210330

--- a/data/pubmed/affiliations.tsv.gz
+++ b/data/pubmed/affiliations.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f64e57871109df49e32b8139c719e7b3e2bcab79fbf5a19e08149398a1633d5c
+size 16819377

--- a/data/pubmed/articles.tsv.gz
+++ b/data/pubmed/articles.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc872e9f64de4670b2d813b6be03aca70db02975fe43cf3c21933b4941ee41be
+size 10474759

--- a/data/pubmed/authors.tsv.gz
+++ b/data/pubmed/authors.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e9bcf46ea63d14d00225063a858fdb4be62671ff2370b91e863aea5d25cef52
+size 13104389

--- a/data/pubmed/efetch/BMC Bioinformatics.xml.gz
+++ b/data/pubmed/efetch/BMC Bioinformatics.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4334ae0504202165f23c399651afac828a34b53f57b23a0b9e473f7980bd250e
+size 17809079

--- a/data/pubmed/efetch/Bioinformatics.xml.gz
+++ b/data/pubmed/efetch/Bioinformatics.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bb62005063a436bd64a7474771fdf19dac551dd5fcab707008d04c54dc7bdc5
+size 15670829

--- a/data/pubmed/efetch/PLoS Comput Biol.xml.gz
+++ b/data/pubmed/efetch/PLoS Comput Biol.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c39bbfe9319e02c110b4bcb6cf6eb4a451d18f85cdfc4d7cc60613daf85cd6e
+size 15883208

--- a/data/pubmed/efetch/compbio-english.xml.gz
+++ b/data/pubmed/efetch/compbio-english.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80857be6705251cf0aaf0cf61d0090a8d91572acd2bba4cf52158e7102d390cf
+size 359485614

--- a/data/pubmed/efetch/compbio.xml.gz
+++ b/data/pubmed/efetch/compbio.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c73ff77300cadfdcf2a77dca96e372f11b611b877439bd526f879bf976c10620
+size 357143274

--- a/data/pubmed/esummary/compbio-english.xml.gz
+++ b/data/pubmed/esummary/compbio-english.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e10705a4567ee7520b648e2190a5a0d4be805da61a6037aa3013904358f3423
+size 42509942

--- a/readme.md
+++ b/readme.md
@@ -10,10 +10,12 @@ Make sure to have Git LFS installed locally before cloning the repository,
 if you'd like to download the datasets.
 You can also download datasets directly from the GitHub website by clicking "Raw".
 
-In general, we use [XZ](https://tukaani.org/xz/) for compressing files (denoted by an `.xz` extension).
-For users that would like a graphical interface for decompressing XZ-compressed files,
-options include [PeaZip](https://giorgiotani.github.io/PeaZip/) on Windows (open source) and [The Unarchiver](https://theunarchiver.com/) on macOS (proprietary freeware).
-macOS users can install the `xz` command line utility with `brew install xz`.
+The source code saves large files using [XZ](https://tukaani.org/xz/) compression (denoted by an `.xz` extension).
+Since not all users are familiar with XZ-compression,
+we have also created gzip exports of all XZ-compressed files
+(with the [`convert-xz-to-gzip.bash`](utils/convert-xz-to-gzip.bash) script).
+These files are placed alongside their XZ source in the `data` directory.
+The source code pipelines use XZ compression since gzip encodes a timestamp causing non-deterministic output files.
 
 ## Development
 

--- a/utils/convert-xz-to-gzip.bash
+++ b/utils/convert-xz-to-gzip.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+## convert-xz-to-gzip.bash:
+## Create a copy of XZ compressed files with gzip compression instead.
+## Run this script from the repository's root directory.
+
+shopt -s nullglob
+shopt -s globstar
+
+for xz_path in **/*.xz; do
+    echo >&2 $xz_path
+    # use --no-name for reproducible output
+    xz --decompress --stdout "$xz_path" | gzip --no-name --best > "${xz_path%.xz}.gz"
+done


### PR DESCRIPTION
A couple reviewers requested gzip compression. This PR creates a gzip copy of every XZ compressed file. Adds approx 1 GB of files to GitHub LFS.